### PR TITLE
Feature files

### DIFF
--- a/src/main/java/com/tdei/gateway/gtfsflex/controller/GtfsFlexController.java
+++ b/src/main/java/com/tdei/gateway/gtfsflex/controller/GtfsFlexController.java
@@ -21,7 +21,6 @@ import javax.servlet.http.HttpServletResponse;
 import java.io.FileNotFoundException;
 import java.io.IOException;
 import java.security.Principal;
-import java.util.Date;
 import java.util.List;
 import java.util.Optional;
 
@@ -44,7 +43,7 @@ public class GtfsFlexController implements IGtfsFlex {
         return ResponseEntity.ok().body(resource);
     }
 
-    public ResponseEntity<List<GtfsFlexDownload>> listFlexFiles(Principal principal, HttpServletRequest req, Optional<String> tdeiServiceId, Optional<Double[]> bbox, Optional<String> flexSchemaVersion, Optional<String> tdeiOrgId, Optional<Date> dateTime, Optional<String> tdeiRecordId, Integer pageNo, Integer pageSize) throws FileNotFoundException {
+    public ResponseEntity<List<GtfsFlexDownload>> listFlexFiles(Principal principal, HttpServletRequest req, Optional<String> tdeiServiceId, Optional<Double[]> bbox, Optional<String> flexSchemaVersion, Optional<String> tdeiOrgId, Optional<String> dateTime, Optional<String> tdeiRecordId, Integer pageNo, Integer pageSize) throws FileNotFoundException {
         return ResponseEntity.ok(gtfsFlexService.listFlexFiles(principal, req.getServletPath(), tdeiServiceId, bbox, Optional.of(0), flexSchemaVersion, dateTime, tdeiOrgId, tdeiRecordId, pageNo, pageSize));
     }
 
@@ -57,7 +56,7 @@ public class GtfsFlexController implements IGtfsFlex {
     public ResponseEntity<String> uploadGtfsFlexFile(Principal principal, GtfsFlexUpload meta, MultipartFile file, HttpServletRequest httpServletRequest) throws FileUploadException {
         return ResponseEntity.accepted().body(gtfsFlexService.uploadFlexFile(principal, meta, file));
     }
-    
+
     @Override
     public ResponseEntity<List<GtfsFlexServiceModel>> listFlexServices(Principal principal, HttpServletRequest httpServletRequest, Optional<String> ownerOrg, Integer pageNo, Integer pageSize) {
         List<GtfsFlexServiceModel> response = gtfsFlexService.listFlexServices(principal, httpServletRequest, ownerOrg, pageNo, pageSize);

--- a/src/main/java/com/tdei/gateway/gtfsflex/controller/contract/IGtfsFlex.java
+++ b/src/main/java/com/tdei/gateway/gtfsflex/controller/contract/IGtfsFlex.java
@@ -14,7 +14,6 @@ import io.swagger.v3.oas.annotations.responses.ApiResponse;
 import io.swagger.v3.oas.annotations.responses.ApiResponses;
 import io.swagger.v3.oas.annotations.security.SecurityRequirement;
 import org.apache.tomcat.util.http.fileupload.FileUploadException;
-import org.springframework.format.annotation.DateTimeFormat;
 import org.springframework.http.MediaType;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.access.prepost.PreAuthorize;
@@ -29,7 +28,6 @@ import javax.validation.constraints.NotNull;
 import java.io.FileNotFoundException;
 import java.io.IOException;
 import java.security.Principal;
-import java.util.Date;
 import java.util.List;
 import java.util.Optional;
 
@@ -83,8 +81,8 @@ public interface IGtfsFlex {
                                                          @Parameter(in = ParameterIn.QUERY,
                                                                  description = "tdei-assigned organization id. Necessary to ensure that agency ids are unique. Represented as a UUID.", schema = @Schema())
                                                          @Valid @RequestParam(value = " tdei_org_id", required = false) Optional<String> tdeiOrgId,
-                                                         @Parameter(in = ParameterIn.QUERY, description = "date-time (Format. YYYY-MM-DD) for which the caller is interested in obtaining files. all files that are valid at the specified date-time and meet the other criteria will be returned.",
-                                                                 schema = @Schema()) @Valid @RequestParam(value = "date_time", required = false) @DateTimeFormat(pattern = "yyyy-MM-dd") Optional<Date> dateTime,
+                                                         @Parameter(in = ParameterIn.QUERY, description = "date-time for which the caller is interested in obtaining files. all files that are valid at the specified date-time and meet the other criteria will be returned.",
+                                                                 schema = @Schema()) @Valid @RequestParam(value = "date_time", required = false) Optional<String> dateTime,
                                                          @Parameter(in = ParameterIn.QUERY, description = "if included, returns the metadata for the specified file, all other parameters will be ignored.", schema = @Schema())
                                                          @Valid @RequestParam(value = "tdei_record_id", required = false) Optional<String> tdeiRecordId,
                                                          @Parameter(in = ParameterIn.QUERY, description = "Integer, defaults to 1.", schema = @Schema()) @Valid @RequestParam(value = "page_no", required = false, defaultValue = "1") Integer pageNo,

--- a/src/main/java/com/tdei/gateway/gtfsflex/model/dto/GtfsFlexDownload.java
+++ b/src/main/java/com/tdei/gateway/gtfsflex/model/dto/GtfsFlexDownload.java
@@ -1,6 +1,5 @@
 package com.tdei.gateway.gtfsflex.model.dto;
 
-import com.fasterxml.jackson.annotation.JsonFormat;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.tdei.gateway.main.model.common.dto.GeoJsonObject;
 import io.swagger.v3.oas.annotations.media.Schema;
@@ -9,7 +8,6 @@ import org.springframework.validation.annotation.Validated;
 
 import javax.validation.Valid;
 import javax.validation.constraints.NotNull;
-import java.time.LocalDateTime;
 
 /**
  * Represents a gtfs_flex data file.
@@ -32,8 +30,7 @@ public class GtfsFlexDownload {
     @NotNull
     @Valid
     @JsonProperty("collection_date")
-    @JsonFormat(shape = JsonFormat.Shape.STRING, pattern = "yyyy-MM-dd'T'HH:mm:ss.SSS'Z'")
-    private LocalDateTime collectionDate = null;
+    private String collectionDate = null;
 
     @Schema(required = true, description = "Method by which the data was collected. See Best Practices document for information on how to format this string.")
     @NotNull
@@ -44,14 +41,12 @@ public class GtfsFlexDownload {
     @NotNull
     @Valid
     @JsonProperty("valid_from")
-    @JsonFormat(shape = JsonFormat.Shape.ANY, pattern = "yyyy-MM-dd'T'HH:mm:ss.SSS'Z'")
-    private LocalDateTime validFrom = null;
+    private String validFrom = null;
 
     @Schema(description = "date until which this data is valid")
     @Valid
     @JsonProperty("valid_to")
-    @JsonFormat(shape = JsonFormat.Shape.STRING, pattern = "yyyy-MM-dd'T'HH:mm:ss.SSS'Z'")
-    private LocalDateTime validTo = null;
+    private String validTo = null;
 
     @Schema(required = true, description = "tdei-generated confidence level. Confidence level range is: 0 (very low confidence) to 100 (very high confidence).")
     @NotNull

--- a/src/main/java/com/tdei/gateway/gtfsflex/model/dto/GtfsFlexDownload.java
+++ b/src/main/java/com/tdei/gateway/gtfsflex/model/dto/GtfsFlexDownload.java
@@ -21,6 +21,10 @@ public class GtfsFlexDownload {
     @JsonProperty("tdei_org_id")
     private String tdeiOrgId = null;
 
+    @Schema(required = true, description = "tdei-assigned service id. Represented as UUID. Station ids can be retrieved using the /api/v1/services path.")
+    @JsonProperty("tdei_service_id")
+    private String tdeiServiceId = null;
+
     @Schema(required = true, description = "Description of who data was collected by. See Best Practices document for information on how to format this string.")
     @NotNull
     @JsonProperty("collected_by")

--- a/src/main/java/com/tdei/gateway/gtfsflex/model/dto/GtfsFlexUpload.java
+++ b/src/main/java/com/tdei/gateway/gtfsflex/model/dto/GtfsFlexUpload.java
@@ -1,6 +1,5 @@
 package com.tdei.gateway.gtfsflex.model.dto;
 
-import com.fasterxml.jackson.annotation.JsonFormat;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.tdei.gateway.main.model.common.dto.GeoJsonObject;
 import io.swagger.v3.oas.annotations.media.Schema;
@@ -9,7 +8,6 @@ import org.springframework.validation.annotation.Validated;
 
 import javax.validation.Valid;
 import javax.validation.constraints.NotNull;
-import java.time.LocalDateTime;
 
 /**
  * represents meta data needed to upload a gtfs_flex data file
@@ -37,8 +35,7 @@ public class GtfsFlexUpload {
     @NotNull
     @Valid
     @JsonProperty("collection_date")
-    @JsonFormat(shape = JsonFormat.Shape.ANY, pattern = "yyyy-MM-dd'T'HH:mm:ss.SSS'Z'")
-    private LocalDateTime collectionDate = null;
+    private String collectionDate = null;
 
     @Schema(required = true, description = "Method by which the data was collected. See Best Practices document for information on how to format this string.")
     @NotNull
@@ -49,14 +46,12 @@ public class GtfsFlexUpload {
     @NotNull
     @Valid
     @JsonProperty("valid_from")
-    @JsonFormat(shape = JsonFormat.Shape.ANY, pattern = "yyyy-MM-dd'T'HH:mm:ss.SSS'Z'")
-    private LocalDateTime validFrom = null;
+    private String validFrom = null;
 
     @Schema(description = "date until which this data is valid")
     @Valid
     @JsonProperty("valid_to")
-    @JsonFormat(shape = JsonFormat.Shape.ANY, pattern = "yyyy-MM-dd'T'HH:mm:ss.SSS'Z'")
-    private LocalDateTime validTo = null;
+    private String validTo = null;
 
     @Schema(required = true, description = "Description of data source or sources from which the data was collected. See Best Practices document for information on how to format this string.")
     @NotNull

--- a/src/main/java/com/tdei/gateway/gtfsflex/service/GtfsFlexService.java
+++ b/src/main/java/com/tdei/gateway/gtfsflex/service/GtfsFlexService.java
@@ -36,11 +36,9 @@ import java.io.InputStream;
 import java.io.SequenceInputStream;
 import java.security.Principal;
 import java.util.Arrays;
-import java.util.Date;
 import java.util.List;
 import java.util.Optional;
 
-import static com.tdei.gateway.core.utils.Utils.formatDate;
 import static org.springframework.http.MediaType.ALL;
 import static org.springframework.http.MediaType.APPLICATION_JSON;
 
@@ -123,7 +121,7 @@ public class GtfsFlexService implements IGtfsFlexService {
                                                 Optional<Double[]> bbox,
                                                 Optional<Integer> confidenceLevel,
                                                 Optional<String> flexSchemaVersion,
-                                                Optional<Date> dateTime,
+                                                Optional<String> dateTime,
                                                 Optional<String> tdeiOrgId,
                                                 Optional<String> tdeiRecordId,
                                                 Integer pageNo,
@@ -148,7 +146,7 @@ public class GtfsFlexService implements IGtfsFlexService {
             if (flexSchemaVersion.isPresent())
                 uri.queryParam("flex_schema_version", flexSchemaVersion.get());
             if (dateTime.isPresent())
-                uri.queryParam("date_time", formatDate(dateTime.get(), Optional.empty()));
+                uri.queryParam("date_time", dateTime.get());
             if (tdeiOrgId.isPresent())
                 uri.queryParam("tdei_org_id", tdeiOrgId.get());
             if (tdeiRecordId.isPresent())

--- a/src/main/java/com/tdei/gateway/gtfsflex/service/contract/IGtfsFlexService.java
+++ b/src/main/java/com/tdei/gateway/gtfsflex/service/contract/IGtfsFlexService.java
@@ -13,7 +13,6 @@ import javax.servlet.http.HttpServletRequest;
 import java.io.FileNotFoundException;
 import java.io.InputStream;
 import java.security.Principal;
-import java.util.Date;
 import java.util.List;
 import java.util.Optional;
 
@@ -55,7 +54,7 @@ public interface IGtfsFlexService {
                                          Optional<Double[]> bbox,
                                          Optional<Integer> confidenceLevel,
                                          Optional<String> flexSchemaVersion,
-                                         Optional<Date> dateTime,
+                                         Optional<String> dateTime,
                                          Optional<String> tdeiOrgId,
                                          Optional<String> tdeiRecordId,
                                          Integer pageNo,

--- a/src/main/java/com/tdei/gateway/gtfspathways/controller/GtfsPathwaysController.java
+++ b/src/main/java/com/tdei/gateway/gtfspathways/controller/GtfsPathwaysController.java
@@ -21,7 +21,6 @@ import javax.servlet.http.HttpServletResponse;
 import java.io.FileNotFoundException;
 import java.io.IOException;
 import java.security.Principal;
-import java.util.Date;
 import java.util.List;
 import java.util.Optional;
 
@@ -45,7 +44,7 @@ public class GtfsPathwaysController implements IGtfsPathways {
     @Override
     public ResponseEntity<List<GtfsPathwaysDownload>> listPathwaysFiles(Principal principal, HttpServletRequest req, Optional<Double[]> bbox, Optional<String> tdeiStationId,
 //                                                                        Optional<Integer> confidenceLevel,
-                                                                        Optional<String> pathwaysSchemaVersion, Optional<Date> dateTime, Optional<String> tdeiOrgId, Optional<String> tdeiRecordId, Integer pageNo, Integer pageSize) throws FileNotFoundException {
+                                                                        Optional<String> pathwaysSchemaVersion, Optional<String> dateTime, Optional<String> tdeiOrgId, Optional<String> tdeiRecordId, Integer pageNo, Integer pageSize) throws FileNotFoundException {
 
         return ResponseEntity.ok(gtfsPathwaysService.listPathwaysFiles(principal, req.getServletPath(), bbox, tdeiStationId, Optional.empty(), pathwaysSchemaVersion, dateTime, tdeiOrgId, tdeiRecordId, pageNo, pageSize));
     }

--- a/src/main/java/com/tdei/gateway/gtfspathways/controller/contract/IGtfsPathways.java
+++ b/src/main/java/com/tdei/gateway/gtfspathways/controller/contract/IGtfsPathways.java
@@ -14,7 +14,6 @@ import io.swagger.v3.oas.annotations.responses.ApiResponse;
 import io.swagger.v3.oas.annotations.responses.ApiResponses;
 import io.swagger.v3.oas.annotations.security.SecurityRequirement;
 import org.apache.tomcat.util.http.fileupload.FileUploadException;
-import org.springframework.format.annotation.DateTimeFormat;
 import org.springframework.http.MediaType;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.access.prepost.PreAuthorize;
@@ -29,7 +28,6 @@ import javax.validation.constraints.NotNull;
 import java.io.FileNotFoundException;
 import java.io.IOException;
 import java.security.Principal;
-import java.util.Date;
 import java.util.List;
 import java.util.Optional;
 
@@ -80,8 +78,8 @@ public interface IGtfsPathways {
 //                    schema = @Schema()) @Valid @RequestParam(value = "confidence_level", required = false) Optional<Integer> confidenceLevel,
             @Parameter(in = ParameterIn.QUERY, description = "version name of the pathways schema version that the application requests. list of versions can be found with /api/v1/gtfs-pathways/versions path",
                     schema = @Schema()) @Valid @RequestParam(value = "pathways_schema_version", required = false) Optional<String> pathwaysSchemaVersion,
-            @Parameter(in = ParameterIn.QUERY, description = "date-time (Format. YYYY-MM-DD) for which the caller is interested in obtaining files. all files that are valid at the specified date-time and meet the other criteria will be returned.",
-                    schema = @Schema()) @Valid @RequestParam(value = "date_time", required = false) @DateTimeFormat(pattern = "yyyy-MM-dd") Optional<Date> dateTime,
+            @Parameter(in = ParameterIn.QUERY, description = "date-time for which the caller is interested in obtaining files. all files that are valid at the specified date-time and meet the other criteria will be returned.",
+                    schema = @Schema()) @Valid @RequestParam(value = "date_time", required = false) Optional<String> dateTime,
             @Parameter(in = ParameterIn.QUERY, description = "tdei-assigned organization id. Necessary to ensure that agency ids are unique. Represented as a UUID.",
                     schema = @Schema()) @Valid @RequestParam(value = "tdei_org_id", required = false) Optional<String> tdeiOrgId,
             @Parameter(in = ParameterIn.QUERY, description = "if included, returns the metadata for the specified file, all other parameters will be ignored.",

--- a/src/main/java/com/tdei/gateway/gtfspathways/model/dto/GtfsPathwaysDownload.java
+++ b/src/main/java/com/tdei/gateway/gtfspathways/model/dto/GtfsPathwaysDownload.java
@@ -1,6 +1,5 @@
 package com.tdei.gateway.gtfspathways.model.dto;
 
-import com.fasterxml.jackson.annotation.JsonFormat;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.tdei.gateway.main.model.common.dto.GeoJsonObject;
 import io.swagger.v3.oas.annotations.media.Schema;
@@ -9,7 +8,6 @@ import org.springframework.validation.annotation.Validated;
 
 import javax.validation.Valid;
 import javax.validation.constraints.NotNull;
-import java.time.LocalDateTime;
 
 /**
  * Describes a gtfs pathways file meta data.
@@ -36,8 +34,7 @@ public class GtfsPathwaysDownload {
     @NotNull
     @Valid
     @JsonProperty("collection_date")
-    @JsonFormat(shape = JsonFormat.Shape.ANY, pattern = "yyyy-MM-dd'T'HH:mm:ss.SSS'Z'")
-    private LocalDateTime collectionDate = null;
+    private String collectionDate = null;
 
     @Schema(required = true, description = "Method by which the data was collected. See Best Practices document for information on how to format this string.")
     @NotNull
@@ -48,14 +45,12 @@ public class GtfsPathwaysDownload {
     @NotNull
     @Valid
     @JsonProperty("valid_from")
-    @JsonFormat(shape = JsonFormat.Shape.ANY, pattern = "yyyy-MM-dd'T'HH:mm:ss.SSS'Z'")
-    private LocalDateTime validFrom = null;
+    private String validFrom = null;
 
     @Schema(description = "date until which this data is valid")
     @Valid
     @JsonProperty("valid_to")
-    @JsonFormat(shape = JsonFormat.Shape.ANY, pattern = "yyyy-MM-dd'T'HH:mm:ss.SSS'Z'")
-    private LocalDateTime validTo = null;
+    private String validTo = null;
 
     @Schema(required = true, description = "tdei-generated confidence level. Confidence level range is: 0 (very low confidence) to 100 (very high confidence).")
     @NotNull

--- a/src/main/java/com/tdei/gateway/gtfspathways/model/dto/GtfsPathwaysUpload.java
+++ b/src/main/java/com/tdei/gateway/gtfspathways/model/dto/GtfsPathwaysUpload.java
@@ -1,6 +1,5 @@
 package com.tdei.gateway.gtfspathways.model.dto;
 
-import com.fasterxml.jackson.annotation.JsonFormat;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.tdei.gateway.main.model.common.dto.GeoJsonObject;
 import io.swagger.v3.oas.annotations.media.Schema;
@@ -9,7 +8,6 @@ import org.springframework.validation.annotation.Validated;
 
 import javax.validation.Valid;
 import javax.validation.constraints.NotNull;
-import java.time.LocalDateTime;
 
 /**
  * Describes a gtfs pathways file meta data. Same as gtfs_pathways, but adds uri.
@@ -32,30 +30,27 @@ public class GtfsPathwaysUpload {
     @JsonProperty("collected_by")
     private String collectedBy = null;
 
-    @Schema(required = true, description = "date-time that data was collected")
+    @Schema(required = true, description = "date-time that data was collected", example = "2016-07-08T12:30:00+05:30")
     @NotNull
     @Valid
     @JsonProperty("collection_date")
-    @JsonFormat(shape = JsonFormat.Shape.ANY, pattern = "yyyy-MM-dd'T'HH:mm:ss.SSS'Z'")
-    private LocalDateTime collectionDate = null;
+    private String collectionDate = null;
 
     @Schema(required = true, description = "Method by which the data was collected.")
     @NotNull
     @JsonProperty("collection_method")
     private String collectionMethod = null;
 
-    @Schema(required = true, description = "date from which this file is valid")
+    @Schema(required = true, description = "date from which this file is valid", example = "2016-07-08T12:30:00+05:30")
     @NotNull
     @Valid
     @JsonProperty("valid_from")
-    @JsonFormat(shape = JsonFormat.Shape.ANY, pattern = "yyyy-MM-dd'T'HH:mm:ss.SSS'Z'")
-    private LocalDateTime validFrom = null;
+    private String validFrom = null;
 
-    @Schema(description = "date until which this data is valid")
+    @Schema(description = "date until which this data is valid", example = "2016-07-08T12:30:00+05:30")
     @Valid
     @JsonProperty("valid_to")
-    @JsonFormat(shape = JsonFormat.Shape.ANY, pattern = "yyyy-MM-dd'T'HH:mm:ss.SSS'Z'")
-    private LocalDateTime validTo = null;
+    private String validTo = null;
 
     @Schema(required = true, description = "Description of data source or sources from which the data was collected.")
     @NotNull

--- a/src/main/java/com/tdei/gateway/gtfspathways/service/GtfsPathwaysService.java
+++ b/src/main/java/com/tdei/gateway/gtfspathways/service/GtfsPathwaysService.java
@@ -35,11 +35,9 @@ import java.io.FileNotFoundException;
 import java.io.InputStream;
 import java.io.SequenceInputStream;
 import java.security.Principal;
-import java.util.Date;
 import java.util.List;
 import java.util.Optional;
 
-import static com.tdei.gateway.core.utils.Utils.formatDate;
 import static org.springframework.http.MediaType.ALL;
 import static org.springframework.http.MediaType.APPLICATION_JSON;
 
@@ -79,6 +77,8 @@ public class GtfsPathwaysService implements IGtfsPathwaysService {
             String filePath = flux.single().block();
             log.info(filePath);
             return filePath;
+        } catch (WebClientResponseException ex) {
+            throw new FileUploadException(ex.getResponseBodyAsString());
         } catch (Exception ex) {
             log.error("Error while uploading file ", ex);
             throw new FileUploadException("Error while uploading file");
@@ -124,7 +124,7 @@ public class GtfsPathwaysService implements IGtfsPathwaysService {
                                                         Optional<String> tdeiStationId,
                                                         Optional<Integer> confidenceLevel,
                                                         Optional<String> pathwaysSchemaVersion,
-                                                        Optional<Date> dateTime,
+                                                        Optional<String> dateTime,
                                                         Optional<String> tdeiOrgId,
                                                         Optional<String> tdeiRecordId,
                                                         Integer pageNo,
@@ -144,7 +144,7 @@ public class GtfsPathwaysService implements IGtfsPathwaysService {
             if (pathwaysSchemaVersion.isPresent())
                 uri.queryParam("pathways_schema_version", pathwaysSchemaVersion.get());
             if (dateTime.isPresent())
-                uri.queryParam("date_time", formatDate(dateTime.get(), Optional.empty()));
+                uri.queryParam("date_time", dateTime.get());
             if (tdeiOrgId.isPresent())
                 uri.queryParam("tdei_org_id", tdeiOrgId.get());
             if (tdeiRecordId.isPresent())

--- a/src/main/java/com/tdei/gateway/gtfspathways/service/contract/IGtfsPathwaysService.java
+++ b/src/main/java/com/tdei/gateway/gtfspathways/service/contract/IGtfsPathwaysService.java
@@ -4,7 +4,6 @@ import com.tdei.gateway.gtfspathways.model.Station;
 import com.tdei.gateway.gtfspathways.model.dto.GtfsPathwaysDownload;
 import com.tdei.gateway.gtfspathways.model.dto.GtfsPathwaysUpload;
 import com.tdei.gateway.main.model.common.dto.VersionSpec;
-import org.apache.tomcat.util.http.fileupload.FileUploadException;
 import org.springframework.http.HttpHeaders;
 import org.springframework.web.multipart.MultipartFile;
 import reactor.util.function.Tuple2;
@@ -14,7 +13,6 @@ import java.io.FileNotFoundException;
 import java.io.IOException;
 import java.io.InputStream;
 import java.security.Principal;
-import java.util.Date;
 import java.util.List;
 import java.util.Optional;
 
@@ -25,7 +23,7 @@ public interface IGtfsPathwaysService {
      * @param principal
      * @param body
      */
-    String uploadPathwaysFile(Principal principal, GtfsPathwaysUpload body, MultipartFile file) throws FileUploadException;
+    String uploadPathwaysFile(Principal principal, GtfsPathwaysUpload body, MultipartFile file) throws Exception;
 
     /**
      * Gets the requested gtfs flex file
@@ -55,7 +53,7 @@ public interface IGtfsPathwaysService {
                                                  Optional<String> tdeiStationId,
                                                  Optional<Integer> confidenceLevel,
                                                  Optional<String> pathwaysSchemaVersion,
-                                                 Optional<Date> dateTime,
+                                                 Optional<String> dateTime,
                                                  Optional<String> tdeiOrgId,
                                                  Optional<String> tdeiRecordId,
                                                  Integer pageNo,

--- a/src/main/java/com/tdei/gateway/osw/controller/OswController.java
+++ b/src/main/java/com/tdei/gateway/osw/controller/OswController.java
@@ -20,7 +20,6 @@ import javax.servlet.http.HttpServletResponse;
 import java.io.FileNotFoundException;
 import java.io.IOException;
 import java.security.Principal;
-import java.util.Date;
 import java.util.List;
 import java.util.Optional;
 
@@ -43,7 +42,7 @@ public class OswController implements IOsw {
     }
 
     @Override
-    public ResponseEntity<List<OswDownload>> listOswFiles(Principal principal, HttpServletRequest req, Optional<Double[]> bbox, Optional<String> oswSchemaVersion, Optional<String> tdeiOrgId, Optional<Date> dateTime, Optional<String> tdeiRecordId, Integer pageNo, Integer pageSize) throws FileNotFoundException {
+    public ResponseEntity<List<OswDownload>> listOswFiles(Principal principal, HttpServletRequest req, Optional<Double[]> bbox, Optional<String> oswSchemaVersion, Optional<String> tdeiOrgId, Optional<String> dateTime, Optional<String> tdeiRecordId, Integer pageNo, Integer pageSize) throws FileNotFoundException {
         return ResponseEntity.ok(oswService.listOswFiles(principal, req.getServletPath(), Optional.empty(), bbox, oswSchemaVersion, dateTime, tdeiOrgId, tdeiRecordId, pageNo, pageSize));
     }
 

--- a/src/main/java/com/tdei/gateway/osw/controller/contract/IOsw.java
+++ b/src/main/java/com/tdei/gateway/osw/controller/contract/IOsw.java
@@ -13,7 +13,6 @@ import io.swagger.v3.oas.annotations.responses.ApiResponse;
 import io.swagger.v3.oas.annotations.responses.ApiResponses;
 import io.swagger.v3.oas.annotations.security.SecurityRequirement;
 import org.apache.tomcat.util.http.fileupload.FileUploadException;
-import org.springframework.format.annotation.DateTimeFormat;
 import org.springframework.http.MediaType;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.access.prepost.PreAuthorize;
@@ -27,7 +26,6 @@ import javax.validation.constraints.NotNull;
 import java.io.FileNotFoundException;
 import java.io.IOException;
 import java.security.Principal;
-import java.util.Date;
 import java.util.List;
 import java.util.Optional;
 
@@ -80,8 +78,8 @@ public interface IOsw {
                                                    @Parameter(in = ParameterIn.QUERY,
                                                            description = "tdei-assigned organization id. Necessary to ensure that agency ids are unique. Represented as a UUID.", schema = @Schema())
                                                    @Valid @RequestParam(value = " tdei_org_id", required = false) Optional<String> tdeiOrgId,
-                                                   @Parameter(in = ParameterIn.QUERY, description = "date-time (Format. YYYY-MM-DD) for which the caller is interested in obtaining files. all files that are valid at the specified date-time and meet the other criteria will be returned.",
-                                                           schema = @Schema()) @Valid @RequestParam(value = "date_time", required = false) @DateTimeFormat(pattern = "yyyy-MM-dd") Optional<Date> dateTime,
+                                                   @Parameter(in = ParameterIn.QUERY, description = "date-time for which the caller is interested in obtaining files. all files that are valid at the specified date-time and meet the other criteria will be returned.",
+                                                           schema = @Schema()) @Valid @RequestParam(value = "date_time", required = false) Optional<String> dateTime,
                                                    @Parameter(in = ParameterIn.QUERY, description = "if included, returns the metadata for the specified file, all other parameters will be ignored.", schema = @Schema())
                                                    @Valid @RequestParam(value = "tdei_record_id", required = false) Optional<String> tdeiRecordId,
                                                    @Parameter(in = ParameterIn.QUERY, description = "Integer, defaults to 1.", schema = @Schema()) @Valid @RequestParam(value = "page_no", required = false, defaultValue = "1") Integer pageNo,

--- a/src/main/java/com/tdei/gateway/osw/model/dto/OswDownload.java
+++ b/src/main/java/com/tdei/gateway/osw/model/dto/OswDownload.java
@@ -1,6 +1,5 @@
 package com.tdei.gateway.osw.model.dto;
 
-import com.fasterxml.jackson.annotation.JsonFormat;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.tdei.gateway.main.model.common.dto.GeoJsonObject;
 import io.swagger.v3.oas.annotations.media.Schema;
@@ -9,7 +8,6 @@ import org.springframework.validation.annotation.Validated;
 
 import javax.validation.Valid;
 import javax.validation.constraints.NotNull;
-import java.time.LocalDateTime;
 
 /**
  * Describes a osw file meta data.
@@ -32,8 +30,7 @@ public class OswDownload {
     @NotNull
     @Valid
     @JsonProperty("collection_date")
-    @JsonFormat(shape = JsonFormat.Shape.ANY, pattern = "yyyy-MM-dd'T'HH:mm:ss.SSS'Z'")
-    private LocalDateTime collectionDate = null;
+    private String collectionDate = null;
 
     @Schema(required = true, description = "Method by which the data was collected. See Best Practices document for information on how to format this string.")
     @NotNull
@@ -44,14 +41,12 @@ public class OswDownload {
     @NotNull
     @Valid
     @JsonProperty("valid_from")
-    @JsonFormat(shape = JsonFormat.Shape.ANY, pattern = "yyyy-MM-dd'T'HH:mm:ss.SSS'Z'")
-    private LocalDateTime validFrom = null;
+    private String validFrom = null;
 
     @Schema(description = "date until which this data is valid")
     @Valid
     @JsonProperty("valid_to")
-    @JsonFormat(shape = JsonFormat.Shape.ANY, pattern = "yyyy-MM-dd'T'HH:mm:ss.SSS'Z'")
-    private LocalDateTime validTo = null;
+    private String validTo = null;
 
     @Schema(required = true, description = "tdei-generated confidence level. Confidence level range is: 0 (very low confidence) to 100 (very high confidence).")
     @NotNull

--- a/src/main/java/com/tdei/gateway/osw/model/dto/OswUpload.java
+++ b/src/main/java/com/tdei/gateway/osw/model/dto/OswUpload.java
@@ -1,6 +1,5 @@
 package com.tdei.gateway.osw.model.dto;
 
-import com.fasterxml.jackson.annotation.JsonFormat;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.tdei.gateway.main.model.common.dto.GeoJsonObject;
 import io.swagger.v3.oas.annotations.media.Schema;
@@ -9,7 +8,6 @@ import org.springframework.validation.annotation.Validated;
 
 import javax.validation.Valid;
 import javax.validation.constraints.NotNull;
-import java.time.LocalDateTime;
 
 /**
  * Describes a osw file meta data.
@@ -32,8 +30,7 @@ public class OswUpload {
     @NotNull
     @Valid
     @JsonProperty("collection_date")
-    @JsonFormat(shape = JsonFormat.Shape.ANY, pattern = "yyyy-MM-dd'T'HH:mm:ss.SSS'Z'")
-    private LocalDateTime collectionDate = null;
+    private String collectionDate = null;
 
     @Schema(required = true, description = "Method by which the data was collected. See Best Practices document for information on how to format this string.")
     @NotNull
@@ -44,14 +41,12 @@ public class OswUpload {
     @NotNull
     @Valid
     @JsonProperty("valid_from")
-    @JsonFormat(shape = JsonFormat.Shape.ANY, pattern = "yyyy-MM-dd'T'HH:mm:ss.SSS'Z'")
-    private LocalDateTime validFrom = null;
+    private String validFrom = null;
 
     @Schema(description = "date until which this data is valid")
     @Valid
     @JsonProperty("valid_to")
-    @JsonFormat(shape = JsonFormat.Shape.ANY, pattern = "yyyy-MM-dd'T'HH:mm:ss.SSS'Z'")
-    private LocalDateTime validTo = null;
+    private String validTo = null;
 
     @Schema(required = true, description = "Description of data source or sources from which the data was collected. See Best Practices document for information on how to format this string.")
     @NotNull

--- a/src/main/java/com/tdei/gateway/osw/service/OswService.java
+++ b/src/main/java/com/tdei/gateway/osw/service/OswService.java
@@ -34,11 +34,9 @@ import java.io.InputStream;
 import java.io.SequenceInputStream;
 import java.security.Principal;
 import java.util.ArrayList;
-import java.util.Date;
 import java.util.List;
 import java.util.Optional;
 
-import static com.tdei.gateway.core.utils.Utils.formatDate;
 import static org.springframework.http.MediaType.ALL;
 import static org.springframework.http.MediaType.APPLICATION_JSON;
 
@@ -120,7 +118,7 @@ public class OswService implements IOswService {
                                           Optional<Integer> confidenceLevel,
                                           Optional<Double[]> bbox,
                                           Optional<String> oswSchemaVersion,
-                                          Optional<Date> dateTime,
+                                          Optional<String> dateTime,
                                           Optional<String> tdeiOrgId,
                                           Optional<String> tdeiRecordId,
                                           Integer pageNo,
@@ -138,7 +136,7 @@ public class OswService implements IOswService {
             if (oswSchemaVersion.isPresent())
                 uri.queryParam("osw_schema_version", oswSchemaVersion.get());
             if (dateTime.isPresent())
-                uri.queryParam("date_time", formatDate(dateTime.get(), Optional.empty()));
+                uri.queryParam("date_time", dateTime.get());
             if (tdeiOrgId.isPresent())
                 uri.queryParam("tdei_org_id", tdeiOrgId.get());
             if (tdeiRecordId.isPresent())

--- a/src/main/java/com/tdei/gateway/osw/service/contract/IOswService.java
+++ b/src/main/java/com/tdei/gateway/osw/service/contract/IOswService.java
@@ -12,7 +12,6 @@ import java.io.FileNotFoundException;
 import java.io.IOException;
 import java.io.InputStream;
 import java.security.Principal;
-import java.util.Date;
 import java.util.List;
 import java.util.Optional;
 
@@ -55,7 +54,7 @@ public interface IOswService {
                                    Optional<Integer> confidenceLevel,
                                    Optional<Double[]> bbox,
                                    Optional<String> oswSchemaVersion,
-                                   Optional<Date> dateTime,
+                                   Optional<String> dateTime,
                                    Optional<String> tdeiOrgId,
                                    Optional<String> tdeiRecordId,
                                    Integer pageNo,

--- a/src/test/java/com/tdei/gateway/unit/auth/CommonControllerTests.java
+++ b/src/test/java/com/tdei/gateway/unit/auth/CommonControllerTests.java
@@ -88,14 +88,14 @@ public class CommonControllerTests {
 
         List<Organization> response = new ArrayList<>();
         Organization agency = new Organization();
-        agency.setOrgName("SDOT");
+        agency.setOrg_name("SDOT");
         response.add(agency);
 
         when(commonService.listOrganizations(any(Principal.class), any(), anyInt(), anyInt())).thenReturn(response);
         var result = commonController.listOrganizations(mockPrincipal, request, 1, 1);
 
         assertThat(result.getStatusCode().value()).isEqualTo(HttpStatus.OK.value());
-        assertThat(result.getBody().stream().findFirst().get().getOrgName()).isEqualTo("SDOT");
+        assertThat(result.getBody().stream().findFirst().get().getOrg_name()).isEqualTo("SDOT");
     }
 
 

--- a/src/test/java/com/tdei/gateway/unit/gtfsflex/GtfsFlexControllerTests.java
+++ b/src/test/java/com/tdei/gateway/unit/gtfsflex/GtfsFlexControllerTests.java
@@ -25,7 +25,10 @@ import java.io.FileNotFoundException;
 import java.io.IOException;
 import java.io.InputStream;
 import java.security.Principal;
-import java.util.*;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.List;
+import java.util.Optional;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.ArgumentMatchers.*;
@@ -73,7 +76,7 @@ public class GtfsFlexControllerTests {
                 Optional.empty(),
                 Optional.of("test"),
                 Optional.of("test"),
-                Optional.of(new Date()),
+                Optional.of("2023-03-03T03:04:00+05:30"),
                 Optional.of("test"),
                 1, 1);
 

--- a/src/test/java/com/tdei/gateway/unit/gtfspathways/GtfsPathwaysControllerTests.java
+++ b/src/test/java/com/tdei/gateway/unit/gtfspathways/GtfsPathwaysControllerTests.java
@@ -6,7 +6,6 @@ import com.tdei.gateway.gtfspathways.model.dto.GtfsPathwaysDownload;
 import com.tdei.gateway.gtfspathways.model.dto.GtfsPathwaysUpload;
 import com.tdei.gateway.gtfspathways.service.GtfsPathwaysService;
 import com.tdei.gateway.main.model.common.dto.VersionSpec;
-import org.apache.tomcat.util.http.fileupload.FileUploadException;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.InjectMocks;
@@ -25,7 +24,10 @@ import java.io.FileNotFoundException;
 import java.io.IOException;
 import java.io.InputStream;
 import java.security.Principal;
-import java.util.*;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.List;
+import java.util.Optional;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.ArgumentMatchers.*;
@@ -90,7 +92,7 @@ public class GtfsPathwaysControllerTests {
                 //Optional.of(1),
                 Optional.of("test"),
                 Optional.of("test"),
-                Optional.of(new Date()),
+                Optional.of("2023-02-02T04:04+05:30"),
                 Optional.of("test"),
                 Optional.of("test"),
                 1, 1);
@@ -117,7 +119,7 @@ public class GtfsPathwaysControllerTests {
     }
 
     @Test
-    void uploadPathwaysFile() throws FileUploadException {
+    void uploadPathwaysFile() throws Exception {
 
         Principal mockPrincipal = mock(Principal.class);
         MockMultipartFile file

--- a/src/test/java/com/tdei/gateway/unit/osw/OswControllerTests.java
+++ b/src/test/java/com/tdei/gateway/unit/osw/OswControllerTests.java
@@ -24,7 +24,10 @@ import java.io.FileNotFoundException;
 import java.io.IOException;
 import java.io.InputStream;
 import java.security.Principal;
-import java.util.*;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.List;
+import java.util.Optional;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.ArgumentMatchers.*;
@@ -71,7 +74,7 @@ public class OswControllerTests {
                 //Optional.of(1),
                 Optional.of("test"),
                 Optional.of("test"),
-                Optional.of(new Date()),
+                Optional.of("2023-03-03T03:04:00+05:30"),
                 Optional.of("test"),
                 1, 1);
 


### PR DESCRIPTION
**Description**:
[Gateway- flex/pathways/osw] Upload should accept timestamp with timezone in date-time field metadata information

**Work Item**: 
https://dev.azure.com/TDEI-UW/TDEI/_workitems/edit/267/

**Implementation**:
flex/pathways/osw upload will accept the date-time value as a string. Date-time string value will be persisted in new database columns (created_date_str, valid_to_str, valid_from_str) and it will continue persisting in current columns as UTC value ( this column will be used for any query/filter).  

**Testing**
Manually end to end testing by hosting environment locally.

**Post Deployment Testing**
Pending