### PR TITLE
Get status is implemented

### DIFF
--- a/src/main/java/com/tdei/gateway/core/config/ApplicationProperties.java
+++ b/src/main/java/com/tdei/gateway/core/config/ApplicationProperties.java
@@ -22,6 +22,7 @@ public class ApplicationProperties {
         private String stationUrl;
         private String serviceUrl;
         private String orgUrl;
+        private String loggerUrl;
     }
 
     @Data

--- a/src/main/java/com/tdei/gateway/core/middleware/AuthInterceptor.java
+++ b/src/main/java/com/tdei/gateway/core/middleware/AuthInterceptor.java
@@ -30,7 +30,6 @@ public
 class AuthInterceptor extends OncePerRequestFilter {
 
     private static final String[] AUTH_WHITELIST = {
-            "/status",
             "/authenticate",
             "/swagger-resources",
             "/swagger-ui",

--- a/src/main/java/com/tdei/gateway/core/middleware/AuthInterceptor.java
+++ b/src/main/java/com/tdei/gateway/core/middleware/AuthInterceptor.java
@@ -30,6 +30,7 @@ public
 class AuthInterceptor extends OncePerRequestFilter {
 
     private static final String[] AUTH_WHITELIST = {
+            "/status",
             "/authenticate",
             "/swagger-resources",
             "/swagger-ui",

--- a/src/main/java/com/tdei/gateway/main/controller/CommonController.java
+++ b/src/main/java/com/tdei/gateway/main/controller/CommonController.java
@@ -6,6 +6,7 @@ import com.tdei.gateway.core.service.auth.AuthService;
 import com.tdei.gateway.main.controller.contract.ICommon;
 import com.tdei.gateway.main.model.common.dto.Organization;
 import com.tdei.gateway.main.model.common.dto.PageableResponse;
+import com.tdei.gateway.main.model.common.dto.RecordStatus;
 import com.tdei.gateway.main.model.common.dto.VersionSpec;
 import com.tdei.gateway.main.service.CommonService;
 import io.swagger.v3.oas.annotations.tags.Tag;
@@ -43,5 +44,10 @@ public class CommonController implements ICommon {
 
         PageableResponse response = commonService.listApiVersions(principal);
         return ResponseEntity.ok(response);
+    }
+
+    @Override
+    public ResponseEntity<RecordStatus> getStatus(String tdeiRecordId) {
+        return ResponseEntity.ok(commonService.getStatus(tdeiRecordId));
     }
 }

--- a/src/main/java/com/tdei/gateway/main/controller/contract/ICommon.java
+++ b/src/main/java/com/tdei/gateway/main/controller/contract/ICommon.java
@@ -9,6 +9,7 @@ import com.tdei.gateway.core.model.authclient.LoginModel;
 import com.tdei.gateway.core.model.authclient.TokenResponse;
 import com.tdei.gateway.main.model.common.dto.Organization;
 import com.tdei.gateway.main.model.common.dto.PageableResponse;
+import com.tdei.gateway.main.model.common.dto.RecordStatus;
 import com.tdei.gateway.main.model.common.dto.VersionSpec;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.Parameter;
@@ -77,6 +78,19 @@ public interface ICommon {
             method = RequestMethod.GET)
 //    @PreAuthorize("@authService.hasPermission(#principal, 'tdei-user')")
     ResponseEntity<PageableResponse<VersionSpec>> listApiVersions(Principal principal);
+
+    @Operation(summary = "Get status", description = "Fetches the status of an uploaded record", tags = {"General"})
+    @ApiResponses(value = {
+            @ApiResponse(responseCode = "200", description = "Returns status of record", content = @Content(mediaType = "application/json", schema = @Schema(implementation = RecordStatus.class))),
+            @ApiResponse(responseCode = "400", description = "Record not found", content = @Content),
+
+//            @ApiResponse(responseCode = "401", description = "This request is unauthorized. appID is invalid. Please obtain a valid application ID (appID).", content = @Content),
+
+            @ApiResponse(responseCode = "500", description = "An server error occurred.", content = @Content)})
+    @RequestMapping(value = "status",
+    produces = {"application/json"},
+    method = RequestMethod.GET)
+    ResponseEntity<RecordStatus> getStatus(@Parameter(in = ParameterIn.QUERY,description = "tdeiRecordId received during upload")String tdeiRecordId);
 
 }
 

--- a/src/main/java/com/tdei/gateway/main/model/common/dto/RecordStatus.java
+++ b/src/main/java/com/tdei/gateway/main/model/common/dto/RecordStatus.java
@@ -1,0 +1,32 @@
+package com.tdei.gateway.main.model.common.dto;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+import io.swagger.v3.oas.annotations.media.Schema;
+import lombok.Data;
+
+/**
+ * Response class for `status` API call
+ */
+@Data
+@Schema(description = "Describes the status of an uploaded record")
+public class RecordStatus {
+
+    @JsonProperty("tdeiRecordId")
+    @Schema(required = true, description = "Record ID of the file generated")
+    private String tdeiRecordId = null;
+    @JsonProperty("stage")
+    @Schema(description = "Current stage of the file processing")
+    private String stage = null;
+
+    @JsonProperty("filePath")
+    @Schema(description = "File path of the uploaded file. Can be empty if upload validation fails")
+    private String filePath = null;
+
+    @JsonProperty("status")
+    @Schema(description = "Current status of processing. (failed, in progress or complete). If failed, shows the failure reason")
+    private String status = null;
+
+    @JsonProperty("isComplete")
+    @Schema(description = "Whether processing is complete. (will be true if any stage fails)")
+    private boolean isComplete = false;
+}

--- a/src/main/java/com/tdei/gateway/main/service/CommonService.java
+++ b/src/main/java/com/tdei/gateway/main/service/CommonService.java
@@ -2,15 +2,20 @@ package com.tdei.gateway.main.service;
 
 import com.tdei.gateway.core.config.ApplicationProperties;
 import com.tdei.gateway.core.config.exception.handler.exceptions.ApplicationException;
+import com.tdei.gateway.core.config.exception.handler.exceptions.ResourceNotFoundException;
 import com.tdei.gateway.main.model.common.dto.Organization;
 import com.tdei.gateway.main.model.common.dto.PageableResponse;
+import com.tdei.gateway.main.model.common.dto.RecordStatus;
 import com.tdei.gateway.main.model.common.dto.VersionSpec;
 import com.tdei.gateway.main.service.contract.ICommonService;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
+import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.stereotype.Service;
 import org.springframework.web.reactive.function.client.WebClient;
+import org.springframework.web.reactive.function.client.WebClientException;
+import org.springframework.web.reactive.function.client.WebClientResponseException;
 import org.springframework.web.util.UriComponentsBuilder;
 import reactor.core.publisher.Mono;
 
@@ -62,5 +67,44 @@ public class CommonService implements ICommonService {
     @Override
     public PageableResponse<VersionSpec> listApiVersions(Principal principal) {
         return new PageableResponse<>();
+    }
+
+    // Get status API inclusion
+
+    @Override
+    public RecordStatus getStatus(String tdeiRecordId) {
+
+        try {
+            WebClient webClient = WebClient.builder()
+                    .build();
+            UriComponentsBuilder uri = UriComponentsBuilder.fromUriString(applicationProperties.getManagementSvc().getLoggerUrl());
+            uri.queryParam("tdeiRecordId", tdeiRecordId);
+            Mono<ResponseEntity<RecordStatus>> status = webClient.get()
+                    .uri(uriBuilder -> uri
+                            .build().toUri())
+//                .headers(httpHeaders -> {
+//                    if (apiKey != null) httpHeaders.set("x-api-key", apiKey);
+//                    if (authToken != null) httpHeaders.set("Authorization", authToken);
+//                })
+                    .accept(APPLICATION_JSON)
+                    .retrieve()
+                    .toEntity(RecordStatus.class);
+
+            var response = status.single().block().getBody();
+            return response;
+        } catch (WebClientResponseException exception){
+            log.error("Webclient exception", exception);
+             if(exception.getStatusCode() == HttpStatus.NOT_FOUND){
+                 throw new ResourceNotFoundException("Record Not found for "+tdeiRecordId);
+             }
+            throw exception;
+        }
+
+        catch (Exception e){
+            log.error("Error while listing organization ", e);
+
+            throw new ApplicationException("Error while fetching status");
+        }
+
     }
 }

--- a/src/main/java/com/tdei/gateway/main/service/contract/ICommonService.java
+++ b/src/main/java/com/tdei/gateway/main/service/contract/ICommonService.java
@@ -2,6 +2,7 @@ package com.tdei.gateway.main.service.contract;
 
 import com.tdei.gateway.main.model.common.dto.Organization;
 import com.tdei.gateway.main.model.common.dto.PageableResponse;
+import com.tdei.gateway.main.model.common.dto.RecordStatus;
 import com.tdei.gateway.main.model.common.dto.VersionSpec;
 
 import javax.servlet.http.HttpServletRequest;
@@ -25,5 +26,7 @@ public interface ICommonService {
      * @return Paginated list of api versions
      */
     PageableResponse<VersionSpec> listApiVersions(Principal principal);
+
+    RecordStatus getStatus(String tdeiRecordId);
 
 }

--- a/src/main/resources/application-dev.yaml
+++ b/src/main/resources/application-dev.yaml
@@ -13,3 +13,4 @@ management-svc:
   station-url: https://tdei-usermanagement-ts-dev.azurewebsites.net/api/v1/station
   service-url: https://tdei-usermanagement-ts-dev.azurewebsites.net/api/v1/service
   org-url: https://tdei-usermanagement-ts-dev.azurewebsites.net/api/v1/organization
+  logger-url: http://tdei-logger-dev.azurewebsites.net/status

--- a/src/main/resources/application-prod.yaml
+++ b/src/main/resources/application-prod.yaml
@@ -13,3 +13,4 @@ management-svc:
   station-url: https://tdei-usermanagement-ts-prod.azurewebsites.net/api/v1/station
   service-url: https://tdei-usermanagement-ts-prod.azurewebsites.net/api/v1/service
   org-url: https://tdei-usermanagement-ts-prod.azurewebsites.net/api/v1/organization
+  logger-url: http://tdei-logger-prod.azurewebsites.net/status

--- a/src/main/resources/application.yaml
+++ b/src/main/resources/application.yaml
@@ -18,6 +18,7 @@ management-svc:
   station-url: http://localhost:3004/api/v1/station
   service-url: http://localhost:3004/api/v1/service
   org-url: http://localhost:3004/api/v1/organization
+  logger-url: http://localhost:300/status
 spring-doc:
   swagger-ui:
     operationsSorter: alpha


### PR DESCRIPTION
Get status from the logger application is implemented
This API exposes `status` API from logger through gateway

## application.yaml changes
- adds a new loggerUrl to the applicationproperties

## Swagger changes
- Adds additional API to the General section to get the status

## Testing
- Tested using a valid and non-valid tdeiRecordID

This links to #282 task in azure.

### Dependency
- The open API spec also has to be updated after this to reflect the same.