### PR TITLE
Update OswService.java

### DIFF
--- a/src/main/java/com/tdei/gateway/osw/service/OswService.java
+++ b/src/main/java/com/tdei/gateway/osw/service/OswService.java
@@ -2,6 +2,7 @@ package com.tdei.gateway.osw.service;
 
 import com.tdei.gateway.core.config.ApplicationProperties;
 import com.tdei.gateway.core.config.exception.handler.exceptions.ApplicationException;
+import com.tdei.gateway.core.config.exception.handler.exceptions.MetadataValidationException;
 import com.tdei.gateway.core.config.exception.handler.exceptions.ResourceNotFoundException;
 import com.tdei.gateway.core.model.authclient.UserProfile;
 import com.tdei.gateway.main.model.common.dto.VersionList;
@@ -74,7 +75,17 @@ public class OswService implements IOswService {
             String filePath = flux.single().block();
             log.info(filePath);
             return filePath;
-        } catch (Exception ex) {
+        } catch (WebClientResponseException ex) {
+            if (ex.getStatusCode().value() == 404) {
+                throw new ResourceNotFoundException("File not found, Uploaded file might have been invalidated due to possible validations issues.");
+            }
+            if (ex.getStatusCode().equals(HttpStatus.BAD_REQUEST) && !ex.getResponseBodyAsString().isEmpty()) {
+
+                throw new MetadataValidationException("Metadata validation exception", ex.getResponseBodyAsByteArray());
+
+            }
+            throw ex;
+        }catch (Exception ex) {
             log.error("Error while uploading file ", ex);
             throw new FileUploadException("Error while uploading file");
         }


### PR DESCRIPTION
Metadata validation error is handled.
All the metadata errors are sent back appropriately
The validation error from the upload service is not handled or responded back to the user. This bugfix takes care of that.