### PR TITLE
filepath removed

### DIFF
--- a/src/main/java/com/tdei/gateway/main/model/common/dto/RecordStatus.java
+++ b/src/main/java/com/tdei/gateway/main/model/common/dto/RecordStatus.java
@@ -18,10 +18,6 @@ public class RecordStatus {
     @Schema(description = "Current stage of the file processing")
     private String stage = null;
 
-    @JsonProperty("filePath")
-    @Schema(description = "File path of the uploaded file. Can be empty if upload validation fails")
-    private String filePath = null;
-
     @JsonProperty("status")
     @Schema(description = "Current status of processing. (failed, in progress or complete). If failed, shows the failure reason")
     private String status = null;


### PR DESCRIPTION
Filepath is removed from the status
As per the discussion in April 3, the logger service should not respond back with the filepath
- the filepath of the uploaded record is removed
- Swagger is also updated without the filepath
Reference task number : 282