### PR TITLE
Updated file upload size

### DIFF
--- a/src/main/resources/application.yaml
+++ b/src/main/resources/application.yaml
@@ -5,8 +5,8 @@ spring:
     import: optional:developer-local-properties.yaml
   servlet:
     multipart:
-      max-file-size: 15MB
-      max-request-size: 15MB
+      max-file-size: 30MB
+      max-request-size: 30MB
 application:
   app-name: tdei-gateway
   auth-server-url: "${APPLICATION_AUTH_SERVER_URL}"


### PR DESCRIPTION
Default file size upload is restricted to 10MB, we are upgrading the file size upload to support large files