### PR TITLE
Update OswUpload.java

### DIFF
--- a/src/main/java/com/tdei/gateway/osw/model/dto/OswUpload.java
+++ b/src/main/java/com/tdei/gateway/osw/model/dto/OswUpload.java
@@ -63,7 +63,7 @@ public class OswUpload {
     @JsonProperty("polygon")
     private GeoJsonObject polygon = null;
 
-    @Schema(required = true, example = "v1.1", description = "version of osw schema this file conforms to")
+    @Schema(required = true, example = "v0.1", description = "version of osw schema this file conforms to")
     @NotNull
     @JsonProperty("osw_schema_version")
     private String oswSchemaVersion = null;


### PR DESCRIPTION
OSWVersion default and example should be v0.1
This will otherwise show error when tried with swagger.
- The current supported version of OSW is v0.1. However, when trying with swagger, it shows up v1.1 which will eventually fail the request. This PR will solve that issue