### PR TITLE
job unification changes

### DIFF
--- a/config/settings/dev/endpoints.json
+++ b/config/settings/dev/endpoints.json
@@ -25,14 +25,14 @@
             "backend_host": "https://tdei-logger-dev.azurewebsites.net"
         },
         {
-            "endpoint": "/api/v1/osw/dataset-flattern/{tdei_record_id}",
-            "backend_url_pattern": "/api/v1/osw/dataset-flattern/{tdei_record_id}",
+            "endpoint": "/api/v1/osw/dataset-flatten/{tdei_dataset_id}",
+            "backend_url_pattern": "/api/v1/osw/dataset-flatten/{tdei_dataset_id}",
             "http_method": "POST",
             "backend_host": "https://tdei-template-osw-datasvc-ts-dev.azurewebsites.net"
         },
         {
-            "endpoint": "/api/v1/osw/dataset-flattern/status/{job_id}",
-            "backend_url_pattern": "/api/v1/osw/dataset-flattern/status/{job_id}",
+            "endpoint": "/api/v1/job",
+            "backend_url_pattern": "/api/v1/job",
             "http_method": "GET",
             "backend_host": "https://tdei-template-osw-datasvc-ts-dev.azurewebsites.net"
         },
@@ -43,44 +43,14 @@
             "backend_host": "https://tdei-template-osw-datasvc-ts-dev.azurewebsites.net"
         },
         {
-            "endpoint": "/api/v1/osw/dataset-bbox/status/{job_id}",
-            "backend_url_pattern": "/api/v1/osw/dataset-bbox/status/{job_id}",
-            "http_method": "GET",
-            "backend_host": "https://tdei-template-osw-datasvc-ts-dev.azurewebsites.net"
-        },
-        {
-            "endpoint": "/api/v1/osw/dataset-bbox/download/{job_id}",
-            "backend_url_pattern": "/api/v1/osw/dataset-bbox/download/{job_id}",
-            "http_method": "GET",
-            "backend_host": "https://tdei-template-osw-datasvc-ts-dev.azurewebsites.net"
-        },
-        {
-            "endpoint": "/api/v1/osw/upload/status/{tdei_record_id}",
-            "backend_url_pattern": "/api/v1/osw/upload/status/{tdei_record_id}",
-            "http_method": "GET",
-            "backend_host": "https://tdei-template-osw-datasvc-ts-dev.azurewebsites.net"
-        },
-        {
-            "endpoint": "/api/v1/osw/publish/status/{tdei_record_id}",
-            "backend_url_pattern": "/api/v1/osw/publish/status/{tdei_record_id}",
-            "http_method": "GET",
-            "backend_host": "https://tdei-template-osw-datasvc-ts-dev.azurewebsites.net"
-        },
-        {
-            "endpoint": "/api/v1/osw/validate/status/{job_id}",
-            "backend_url_pattern": "/api/v1/osw/validate/status/{job_id}",
-            "http_method": "GET",
-            "backend_host": "https://tdei-template-osw-datasvc-ts-dev.azurewebsites.net"
-        },
-        {
             "endpoint": "/api/v1/project-group",
             "backend_url_pattern": "/api/v1/project-group",
             "http_method": "GET",
             "backend_host": "https://tdei-usermanagement-ts-dev.azurewebsites.net"
         },
         {
-            "endpoint": "/api/v1/osw/{tdei_record_id}",
-            "backend_url_pattern": "/api/v1/osw/{tdei_record_id}",
+            "endpoint": "/api/v1/dataset/{tdei_dataset_id}",
+            "backend_url_pattern": "/api/v1/dataset/{tdei_dataset_id}",
             "http_method": "DELETE",
             "backend_host": "https://tdei-template-osw-datasvc-ts-dev.azurewebsites.net"
         },
@@ -91,8 +61,8 @@
             "backend_host": "https://tdei-template-osw-datasvc-ts-dev.azurewebsites.net"
         },
         {
-            "endpoint": "/api/v1/osw/{tdei_record_id}",
-            "backend_url_pattern": "/api/v1/osw/{tdei_record_id}",
+            "endpoint": "/api/v1/osw/{tdei_dataset_id}",
+            "backend_url_pattern": "/api/v1/osw/{tdei_dataset_id}",
             "http_method": "GET",
             "backend_host": "https://tdei-template-osw-datasvc-ts-dev.azurewebsites.net"
         },
@@ -109,8 +79,8 @@
             "backend_host": "https://tdei-template-osw-datasvc-ts-dev.azurewebsites.net"
         },
         {
-            "endpoint": "/api/v1/osw/publish/{tdei_record_id}",
-            "backend_url_pattern": "/api/v1/osw/publish/{tdei_record_id}",
+            "endpoint": "/api/v1/osw/publish/{tdei_dataset_id}",
+            "backend_url_pattern": "/api/v1/osw/publish/{tdei_dataset_id}",
             "http_method": "POST",
             "backend_host": "https://tdei-template-osw-datasvc-ts-dev.azurewebsites.net"
         },
@@ -121,15 +91,9 @@
             "backend_host": "https://tdei-template-osw-datasvc-ts-dev.azurewebsites.net"
         },
         {
-            "endpoint": "/api/v1/osw/confidence/calculate",
-            "backend_url_pattern": "/api/v1/osw/confidence/calculate",
+            "endpoint": "/api/v1/osw/confidence/calculate/{tdei_dataset_id}",
+            "backend_url_pattern": "/api/v1/osw/confidence/calculate/{tdei_dataset_id}",
             "http_method": "POST",
-            "backend_host": "https://tdei-template-osw-datasvc-ts-dev.azurewebsites.net"
-        },
-        {
-            "endpoint": "/api/v1/osw/confidence/status/{job_id}",
-            "backend_url_pattern": "/api/v1/osw/confidence/status/{job_id}",
-            "http_method": "GET",
             "backend_host": "https://tdei-template-osw-datasvc-ts-dev.azurewebsites.net"
         },
         {
@@ -139,14 +103,8 @@
             "backend_host": "https://tdei-template-osw-datasvc-ts-dev.azurewebsites.net"
         },
         {
-            "endpoint": "/api/v1/osw/convert/status/{job_id}",
-            "backend_url_pattern": "/api/v1/osw/convert/status/{job_id}",
-            "http_method": "GET",
-            "backend_host": "https://tdei-template-osw-datasvc-ts-dev.azurewebsites.net"
-        },
-        {
-            "endpoint": "/api/v1/osw/convert/download/{job_id}",
-            "backend_url_pattern": "/api/v1/osw/convert/download/{job_id}",
+            "endpoint": "/api/v1/job/download/{job_id}",
+            "backend_url_pattern": "/api/v1/job/download/{job_id}",
             "http_method": "GET",
             "backend_host": "https://tdei-template-osw-datasvc-ts-dev.azurewebsites.net"
         },

--- a/config/settings/prod/endpoints.json
+++ b/config/settings/prod/endpoints.json
@@ -19,14 +19,14 @@
             "backend_host": "https://tdei-logger-prod.azurewebsites.net"
         },
         {
-            "endpoint": "/api/v1/osw/dataset-flattern/{tdei_record_id}",
-            "backend_url_pattern": "/api/v1/osw/dataset-flattern/{tdei_record_id}",
+            "endpoint": "/api/v1/osw/dataset-flatten/{tdei_datatset_id}",
+            "backend_url_pattern": "/api/v1/osw/dataset-flatten/{tdei_datatset_id}",
             "http_method": "POST",
             "backend_host": "https://tdei-osw-datasvc-prod.azurewebsites.net"
         },
         {
-            "endpoint": "/api/v1/osw/dataset-flattern/status/{job_id}",
-            "backend_url_pattern": "/api/v1/osw/dataset-flattern/status/{job_id}",
+            "endpoint": "/api/v1/job",
+            "backend_url_pattern": "/api/v1/job",
             "http_method": "GET",
             "backend_host": "https://tdei-osw-datasvc-prod.azurewebsites.net"
         },
@@ -37,44 +37,14 @@
             "backend_host": "https://tdei-osw-datasvc-prod.azurewebsites.net"
         },
         {
-            "endpoint": "/api/v1/osw/dataset-bbox/status/{job_id}",
-            "backend_url_pattern": "/api/v1/osw/dataset-bbox/status/{job_id}",
-            "http_method": "GET",
-            "backend_host": "https://tdei-osw-datasvc-prod.azurewebsites.net"
-        },
-        {
-            "endpoint": "/api/v1/osw/dataset-bbox/download/{job_id}",
-            "backend_url_pattern": "/api/v1/osw/dataset-bbox/download/{job_id}",
-            "http_method": "GET",
-            "backend_host": "https://tdei-osw-datasvc-prod.azurewebsites.net"
-        },
-        {
-            "endpoint": "/api/v1/osw/upload/status/{tdei_record_id}",
-            "backend_url_pattern": "/api/v1/osw/upload/status/{tdei_record_id}",
-            "http_method": "GET",
-            "backend_host": "https://tdei-osw-datasvc-prod.azurewebsites.net"
-        },
-        {
-            "endpoint": "/api/v1/osw/publish/status/{tdei_record_id}",
-            "backend_url_pattern": "/api/v1/osw/publish/status/{tdei_record_id}",
-            "http_method": "GET",
-            "backend_host": "https://tdei-osw-datasvc-prod.azurewebsites.net"
-        },
-        {
-            "endpoint": "/api/v1/osw/validate/status/{job_id}",
-            "backend_url_pattern": "/api/v1/osw/validate/status/{job_id}",
-            "http_method": "GET",
-            "backend_host": "https://tdei-osw-datasvc-prod.azurewebsites.net"
-        },
-        {
             "endpoint": "/api/v1/project-group",
             "backend_url_pattern": "/api/v1/project-group",
             "http_method": "GET",
             "backend_host": "https://tdei-usermanagement-prod.azurewebsites.net"
         },
         {
-            "endpoint": "/api/v1/osw/{tdei_record_id}",
-            "backend_url_pattern": "/api/v1/osw/{tdei_record_id}",
+            "endpoint": "/api/v1/dataset/{tdei_datatset_id}",
+            "backend_url_pattern": "/api/v1/dataset/{tdei_datatset_id}",
             "http_method": "DELETE",
             "backend_host": "https://tdei-usermanagement-prod.azurewebsites.net"
         },
@@ -85,8 +55,8 @@
             "backend_host": "https://tdei-osw-datasvc-prod.azurewebsites.net"
         },
         {
-            "endpoint": "/api/v1/osw/{tdei_record_id}",
-            "backend_url_pattern": "/api/v1/osw/{tdei_record_id}",
+            "endpoint": "/api/v1/osw/{tdei_datatset_id}",
+            "backend_url_pattern": "/api/v1/osw/{tdei_datatset_id}",
             "http_method": "GET",
             "backend_host": "https://tdei-osw-datasvc-prod.azurewebsites.net"
         },
@@ -103,8 +73,8 @@
             "backend_host": "https://tdei-osw-datasvc-prod.azurewebsites.net"
         },
         {
-            "endpoint": "/api/v1/osw/publish/{tdei_record_id}",
-            "backend_url_pattern": "/api/v1/osw/publish/{tdei_record_id}",
+            "endpoint": "/api/v1/osw/publish/{tdei_datatset_id}",
+            "backend_url_pattern": "/api/v1/osw/publish/{tdei_datatset_id}",
             "http_method": "POST",
             "backend_host": "https://tdei-osw-datasvc-prod.azurewebsites.net"
         },
@@ -115,15 +85,9 @@
             "backend_host": "https://tdei-osw-datasvc-prod.azurewebsites.net"
         },
         {
-            "endpoint": "/api/v1/osw/confidence/calculate",
-            "backend_url_pattern": "/api/v1/osw/confidence/calculate",
+            "endpoint": "/api/v1/osw/confidence/calculate/{tdei_datatset_id}",
+            "backend_url_pattern": "/api/v1/osw/confidence/calculate/{tdei_datatset_id}",
             "http_method": "POST",
-            "backend_host": "https://tdei-osw-datasvc-prod.azurewebsites.net"
-        },
-        {
-            "endpoint": "/api/v1/osw/confidence/status/{job_id}",
-            "backend_url_pattern": "/api/v1/osw/confidence/status/{job_id}",
-            "http_method": "GET",
             "backend_host": "https://tdei-osw-datasvc-prod.azurewebsites.net"
         },
         {
@@ -133,14 +97,8 @@
             "backend_host": "https://tdei-osw-datasvc-prod.azurewebsites.net"
         },
         {
-            "endpoint": "/api/v1/osw/convert/status/{job_id}",
-            "backend_url_pattern": "/api/v1/osw/convert/status/{job_id}",
-            "http_method": "GET",
-            "backend_host": "https://tdei-osw-datasvc-prod.azurewebsites.net"
-        },
-        {
-            "endpoint": "/api/v1/osw/convert/download/{job_id}",
-            "backend_url_pattern": "/api/v1/osw/convert/download/{job_id}",
+            "endpoint": "/api/v1/job/download/{job_id}",
+            "backend_url_pattern": "/api/v1/job/download/{job_id}",
             "http_method": "GET",
             "backend_host": "https://tdei-osw-datasvc-prod.azurewebsites.net"
         },

--- a/config/settings/stage/endpoints.json
+++ b/config/settings/stage/endpoints.json
@@ -19,14 +19,14 @@
             "backend_host": "https://tdei-logger-stage.azurewebsites.net"
         },
         {
-            "endpoint": "/api/v1/osw/dataset-flattern/{tdei_record_id}",
-            "backend_url_pattern": "/api/v1/osw/dataset-flattern/{tdei_record_id}",
+            "endpoint": "/api/v1/osw/dataset-flatten/{tdei_datatset_id}",
+            "backend_url_pattern": "/api/v1/osw/dataset-flatten/{tdei_datatset_id}",
             "http_method": "POST",
             "backend_host": "https://tdei-osw-datasvc-stage.azurewebsites.net"
         },
         {
-            "endpoint": "/api/v1/osw/dataset-flattern/status/{job_id}",
-            "backend_url_pattern": "/api/v1/osw/dataset-flattern/status/{job_id}",
+            "endpoint": "/api/v1/job",
+            "backend_url_pattern": "/api/v1/job",
             "http_method": "GET",
             "backend_host": "https://tdei-osw-datasvc-stage.azurewebsites.net"
         },
@@ -37,44 +37,14 @@
             "backend_host": "https://tdei-osw-datasvc-stage.azurewebsites.net"
         },
         {
-            "endpoint": "/api/v1/osw/dataset-bbox/status/{job_id}",
-            "backend_url_pattern": "/api/v1/osw/dataset-bbox/status/{job_id}",
-            "http_method": "GET",
-            "backend_host": "https://tdei-osw-datasvc-stage.azurewebsites.net"
-        },
-        {
-            "endpoint": "/api/v1/osw/dataset-bbox/download/{job_id}",
-            "backend_url_pattern": "/api/v1/osw/dataset-bbox/download/{job_id}",
-            "http_method": "GET",
-            "backend_host": "https://tdei-osw-datasvc-stage.azurewebsites.net"
-        },
-        {
-            "endpoint": "/api/v1/osw/upload/status/{tdei_record_id}",
-            "backend_url_pattern": "/api/v1/osw/upload/status/{tdei_record_id}",
-            "http_method": "GET",
-            "backend_host": "https://tdei-osw-datasvc-stage.azurewebsites.net"
-        },
-        {
-            "endpoint": "/api/v1/osw/publish/status/{tdei_record_id}",
-            "backend_url_pattern": "/api/v1/osw/publish/status/{tdei_record_id}",
-            "http_method": "GET",
-            "backend_host": "https://tdei-osw-datasvc-stage.azurewebsites.net"
-        },
-        {
-            "endpoint": "/api/v1/osw/validate/status/{job_id}",
-            "backend_url_pattern": "/api/v1/osw/validate/status/{job_id}",
-            "http_method": "GET",
-            "backend_host": "https://tdei-osw-datasvc-stage.azurewebsites.net"
-        },
-        {
             "endpoint": "/api/v1/project-group",
             "backend_url_pattern": "/api/v1/project-group",
             "http_method": "GET",
             "backend_host": "https://tdei-usermanagement-stage.azurewebsites.net"
         },
         {
-            "endpoint": "/api/v1/osw/{tdei_record_id}",
-            "backend_url_pattern": "/api/v1/osw/{tdei_record_id}",
+            "endpoint": "/api/v1/dataset/{tdei_datatset_id}",
+            "backend_url_pattern": "/api/v1/dataset/{tdei_datatset_id}",
             "http_method": "DELETE",
             "backend_host": "https://tdei-osw-datasvc-stage.azurewebsites.net"
         },
@@ -85,8 +55,8 @@
             "backend_host": "https://tdei-osw-datasvc-stage.azurewebsites.net"
         },
         {
-            "endpoint": "/api/v1/osw/{tdei_record_id}",
-            "backend_url_pattern": "/api/v1/osw/{tdei_record_id}",
+            "endpoint": "/api/v1/osw/{tdei_datatset_id}",
+            "backend_url_pattern": "/api/v1/osw/{tdei_datatset_id}",
             "http_method": "GET",
             "backend_host": "https://tdei-osw-datasvc-stage.azurewebsites.net"
         },
@@ -103,8 +73,8 @@
             "backend_host": "https://tdei-osw-datasvc-stage.azurewebsites.net"
         },
         {
-            "endpoint": "/api/v1/osw/publish/{tdei_record_id}",
-            "backend_url_pattern": "/api/v1/osw/publish/{tdei_record_id}",
+            "endpoint": "/api/v1/osw/publish/{tdei_datatset_id}",
+            "backend_url_pattern": "/api/v1/osw/publish/{tdei_datatset_id}",
             "http_method": "POST",
             "backend_host": "https://tdei-osw-datasvc-stage.azurewebsites.net"
         },
@@ -115,15 +85,9 @@
             "backend_host": "https://tdei-osw-datasvc-stage.azurewebsites.net"
         },
         {
-            "endpoint": "/api/v1/osw/confidence/calculate",
-            "backend_url_pattern": "/api/v1/osw/confidence/calculate",
+            "endpoint": "/api/v1/osw/confidence/calculate/{tdei_datatset_id}",
+            "backend_url_pattern": "/api/v1/osw/confidence/calculate/{tdei_datatset_id}",
             "http_method": "POST",
-            "backend_host": "https://tdei-osw-datasvc-stage.azurewebsites.net"
-        },
-        {
-            "endpoint": "/api/v1/osw/confidence/status/{job_id}",
-            "backend_url_pattern": "/api/v1/osw/confidence/status/{job_id}",
-            "http_method": "GET",
             "backend_host": "https://tdei-osw-datasvc-stage.azurewebsites.net"
         },
         {
@@ -133,14 +97,8 @@
             "backend_host": "https://tdei-osw-datasvc-stage.azurewebsites.net"
         },
         {
-            "endpoint": "/api/v1/osw/convert/status/{job_id}",
-            "backend_url_pattern": "/api/v1/osw/convert/status/{job_id}",
-            "http_method": "GET",
-            "backend_host": "https://tdei-osw-datasvc-stage.azurewebsites.net"
-        },
-        {
-            "endpoint": "/api/v1/osw/convert/download/{job_id}",
-            "backend_url_pattern": "/api/v1/osw/convert/download/{job_id}",
+            "endpoint": "/api/v1/job/download/{job_id}",
+            "backend_url_pattern": "/api/v1/job/download/{job_id}",
             "http_method": "GET",
             "backend_host": "https://tdei-osw-datasvc-stage.azurewebsites.net"
         },


### PR DESCRIPTION
1. Renamed `tdei_record_id` to `tdei_dataset_id`.
2. Removed job status endpoints for upload, publish, convert, confidence, bbox, and flattening requests.
3. Removed file download endpoint for convert, bbox requests.
4. Introduced two new API endpoints:
   - `/api/v1/job`
   - `/api/v1/job/download/:jobid`
5. Moved the invalidate API from the OSW controller to the general controller.
6. Changed `/confidence/calculate/:{tdei_dataset_id}` to `/confidence/calculate/:{tdei_dataset_id}` instead of getting `tdei_dataset_id` in the body request.