### PR TITLE
timeout increase for endpoints

### DIFF
--- a/config/settings/dev/endpoints.json
+++ b/config/settings/dev/endpoints.json
@@ -112,6 +112,7 @@
         {
             "endpoint": "/api/v1/osw/upload/{tdei_project_group_id}/{tdei_service_id}",
             "backend_url_pattern": "/api/v1/osw/upload/{tdei_project_group_id}/{tdei_service_id}",
+            "timeout": "900s",
             "http_method": "POST",
             "backend_host": "https://tdei-dataservice-dev.azurewebsites.net"
         },
@@ -124,6 +125,7 @@
         {
             "endpoint": "/api/v1/osw/validate",
             "backend_url_pattern": "/api/v1/osw/validate",
+            "timeout": "900s",
             "http_method": "POST",
             "backend_host": "https://tdei-dataservice-dev.azurewebsites.net"
         },
@@ -148,6 +150,7 @@
         {
             "endpoint": "/api/v1/osw/convert",
             "backend_url_pattern": "/api/v1/osw/convert",
+            "timeout": "900s",
             "http_method": "POST",
             "backend_host": "https://tdei-dataservice-dev.azurewebsites.net"
         },
@@ -173,6 +176,7 @@
         {
             "endpoint": "/api/v1/gtfs-flex/upload/{tdei_project_group_id}/{tdei_service_id}",
             "backend_url_pattern": "/api/v1/gtfs-flex/upload/{tdei_project_group_id}/{tdei_service_id}",
+            "timeout": "900s",
             "http_method": "POST",
             "backend_host": "https://tdei-dataservice-dev.azurewebsites.net"
         },
@@ -185,6 +189,7 @@
         {
             "endpoint": "/api/v1/gtfs-flex/validate",
             "backend_url_pattern": "/api/v1/gtfs-flex/validate",
+            "timeout": "900s",
             "http_method": "POST",
             "backend_host": "https://tdei-dataservice-dev.azurewebsites.net"
         },
@@ -203,6 +208,7 @@
         {
             "endpoint": "/api/v1/gtfs-pathways/upload/{tdei_project_group_id}/{tdei_service_id}",
             "backend_url_pattern": "/api/v1/gtfs-pathways/upload/{tdei_project_group_id}/{tdei_service_id}",
+            "timeout": "900s",
             "http_method": "POST",
             "backend_host": "https://tdei-dataservice-dev.azurewebsites.net"
         },
@@ -215,6 +221,7 @@
         {
             "endpoint": "/api/v1/gtfs-pathways/validate",
             "backend_url_pattern": "/api/v1/gtfs-pathways/validate",
+            "timeout": "900s",
             "http_method": "POST",
             "backend_host": "https://tdei-dataservice-dev.azurewebsites.net"
         },

--- a/config/settings/prod/endpoints.json
+++ b/config/settings/prod/endpoints.json
@@ -100,6 +100,7 @@
         {
             "endpoint": "/api/v1/osw/upload/{tdei_project_group_id}/{tdei_service_id}",
             "backend_url_pattern": "/api/v1/osw/upload/{tdei_project_group_id}/{tdei_service_id}",
+            "timeout": "900s",
             "http_method": "POST",
             "backend_host": "https://tdei-datasvc-prod.azurewebsites.net"
         },
@@ -112,6 +113,7 @@
         {
             "endpoint": "/api/v1/osw/validate",
             "backend_url_pattern": "/api/v1/osw/validate",
+            "timeout": "900s",
             "http_method": "POST",
             "backend_host": "https://tdei-datasvc-prod.azurewebsites.net"
         },
@@ -136,6 +138,7 @@
         {
             "endpoint": "/api/v1/osw/convert",
             "backend_url_pattern": "/api/v1/osw/convert",
+            "timeout": "900s",
             "http_method": "POST",
             "backend_host": "https://tdei-datasvc-prod.azurewebsites.net"
         },
@@ -161,6 +164,7 @@
         {
             "endpoint": "/api/v1/gtfs-flex/upload/{tdei_project_group_id}/{tdei_service_id}",
             "backend_url_pattern": "/api/v1/gtfs-flex/upload/{tdei_project_group_id}/{tdei_service_id}",
+            "timeout": "900s",
             "http_method": "POST",
             "backend_host": "https://tdei-datasvc-prod.azurewebsites.net"
         },
@@ -173,6 +177,7 @@
         {
             "endpoint": "/api/v1/gtfs-flex/validate",
             "backend_url_pattern": "/api/v1/gtfs-flex/validate",
+            "timeout": "900s",
             "http_method": "POST",
             "backend_host": "https://tdei-datasvc-prod.azurewebsites.net"
         },
@@ -191,6 +196,7 @@
         {
             "endpoint": "/api/v1/gtfs-pathways/upload/{tdei_project_group_id}/{tdei_service_id}",
             "backend_url_pattern": "/api/v1/gtfs-pathways/upload/{tdei_project_group_id}/{tdei_service_id}",
+            "timeout": "900s",
             "http_method": "POST",
             "backend_host": "https://tdei-datasvc-prod.azurewebsites.net"
         },
@@ -203,6 +209,7 @@
         {
             "endpoint": "/api/v1/gtfs-pathways/validate",
             "backend_url_pattern": "/api/v1/gtfs-pathways/validate",
+            "timeout": "900s",
             "http_method": "POST",
             "backend_host": "https://tdei-datasvc-prod.azurewebsites.net"
         },

--- a/config/settings/stage/endpoints.json
+++ b/config/settings/stage/endpoints.json
@@ -100,6 +100,7 @@
         {
             "endpoint": "/api/v1/osw/upload/{tdei_project_group_id}/{tdei_service_id}",
             "backend_url_pattern": "/api/v1/osw/upload/{tdei_project_group_id}/{tdei_service_id}",
+            "timeout": "900s",
             "http_method": "POST",
             "backend_host": "https://tdei-osw-datasvc-stage.azurewebsites.net"
         },
@@ -112,6 +113,7 @@
         {
             "endpoint": "/api/v1/osw/validate",
             "backend_url_pattern": "/api/v1/osw/validate",
+            "timeout": "900s",
             "http_method": "POST",
             "backend_host": "https://tdei-osw-datasvc-stage.azurewebsites.net"
         },
@@ -136,6 +138,7 @@
         {
             "endpoint": "/api/v1/osw/convert",
             "backend_url_pattern": "/api/v1/osw/convert",
+            "timeout": "900s",
             "http_method": "POST",
             "backend_host": "https://tdei-osw-datasvc-stage.azurewebsites.net"
         },
@@ -161,6 +164,7 @@
         {
             "endpoint": "/api/v1/gtfs-flex/upload/{tdei_project_group_id}/{tdei_service_id}",
             "backend_url_pattern": "/api/v1/gtfs-flex/upload/{tdei_project_group_id}/{tdei_service_id}",
+            "timeout": "900s",
             "http_method": "POST",
             "backend_host": "https://tdei-osw-datasvc-stage.azurewebsites.net"
         },
@@ -173,6 +177,7 @@
         {
             "endpoint": "/api/v1/gtfs-flex/validate",
             "backend_url_pattern": "/api/v1/gtfs-flex/validate",
+            "timeout": "900s",
             "http_method": "POST",
             "backend_host": "https://tdei-osw-datasvc-stage.azurewebsites.net"
         },
@@ -191,6 +196,7 @@
         {
             "endpoint": "/api/v1/gtfs-pathways/upload/{tdei_project_group_id}/{tdei_service_id}",
             "backend_url_pattern": "/api/v1/gtfs-pathways/upload/{tdei_project_group_id}/{tdei_service_id}",
+            "timeout": "900s",
             "http_method": "POST",
             "backend_host": "https://tdei-osw-datasvc-stage.azurewebsites.net"
         },
@@ -203,6 +209,7 @@
         {
             "endpoint": "/api/v1/gtfs-pathways/validate",
             "backend_url_pattern": "/api/v1/gtfs-pathways/validate",
+            "timeout": "900s",
             "http_method": "POST",
             "backend_host": "https://tdei-osw-datasvc-stage.azurewebsites.net"
         },


### PR DESCRIPTION
## DevBoard Task  
https://dev.azure.com/TDEI-UW/TDEI/_workitems/edit/1680

## Changes Introduced  
- Increased the endpoint timeouts to 15min for load heave endpoints to support heavy file streaming /upload, /validate, /convert. 

## Impacted Areas for Testing  
- Test /upload, /validate, /convert  endpoints with concurrency and big files and ensure no timeouts occurs till file is streamed completely. 
